### PR TITLE
Changed IOLoop.instance() for IOLoop.current()

### DIFF
--- a/server.py
+++ b/server.py
@@ -16,7 +16,7 @@ def main():
         #app will listen on port 80
         app.listen(80)
         #Starting the server
-        IOLoop.instance().start()
+        IOLoop.current().start()
 
     except KeyboardInterrupt:
         exit()


### PR DESCRIPTION
It's specified in the [documentation](http://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.instance) that in single thread applications one should use IOLoop.current().
